### PR TITLE
Adapt for older Qt 6 releases and adjust build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ ubuntu-20.04, ubuntu-22.04, ubuntu-24.04 ]
+        os: [ ubuntu-22.04, ubuntu-24.04 ]
         compiler: [ clang++, g++ ]
 
     runs-on: ${{ matrix.os }}
@@ -14,10 +14,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Install Qt5
+      - name: Install Qt6
         run: |
           sudo apt-get update
-          sudo apt-get -y install  qtbase5-dev qtbase5-dev-tools libzip-dev
+          sudo apt-get -y install  qt6-base-dev qt6-base-dev-tools libzip-dev
 
       - name: CMake
         env:

--- a/README.rst
+++ b/README.rst
@@ -55,11 +55,11 @@ Building and Installing
 
 Requirements:
 
-* Qt5 or Qt6
+* Qt6
 * libzip (Debian/Ubuntu: libzip-dev)
 * CMake
 * C++17 compiler
-* Tested on Ubuntu 20.04, Ubuntu 22.04, Ubuntu 24.04, and OpenBSD 7.6
+* Ubuntu 22.04, Ubuntu 24.04, and OpenBSD 7.8
 
 Compilation:
 

--- a/gpx.cc
+++ b/gpx.cc
@@ -55,7 +55,7 @@ GpxFormat::write(QIODevice* io, const Geodata* geodata)
 
   QString time;
   if (testmode) {
-    time = QDateTime::fromSecsSinceEpoch(0, QTimeZone::UTC).toString(Qt::ISODate);
+    time = QDateTime::fromSecsSinceEpoch(0, QTimeZone("UTC")).toString(Qt::ISODate);
   } else {
     time = QDateTime::currentDateTimeUtc().toString(Qt::ISODate);
   }

--- a/testdata/ggv_bin-sample-v2.gpx
+++ b/testdata/ggv_bin-sample-v2.gpx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gpx version="1.0" creator="ggvtogpx" xmlns="http://www.topografix.com/GPX/1/0">
-  <time>1970-01-01T00:00:00Z</time>
+  <time>1970-01-01T00:00:00+00:00</time>
   <bounds minlat="48.270182777" minlon="11.123582605" maxlat="48.272877253" maxlon="11.131655554"/>
   <trk>
     <trkseg>

--- a/testdata/ggv_bin-sample-v3.gpx
+++ b/testdata/ggv_bin-sample-v3.gpx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gpx version="1.0" creator="ggvtogpx" xmlns="http://www.topografix.com/GPX/1/0">
-  <time>1970-01-01T00:00:00Z</time>
+  <time>1970-01-01T00:00:00+00:00</time>
   <bounds minlat="51.390787309" minlon="7.634582135" maxlat="51.416622730" maxlon="7.670407825"/>
   <wpt lat="51.400591976" lon="7.655250113">
     <name>Beispiel-Text</name>

--- a/testdata/ggv_bin-sample-v4.gpx
+++ b/testdata/ggv_bin-sample-v4.gpx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gpx version="1.0" creator="ggvtogpx" xmlns="http://www.topografix.com/GPX/1/0">
-  <time>1970-01-01T00:00:00Z</time>
+  <time>1970-01-01T00:00:00+00:00</time>
   <bounds minlat="48.061223531" minlon="9.934377854" maxlat="50.119205792" maxlon="12.844931629"/>
   <wpt lat="49.936238687" lon="9.934377854">
     <name>Unterfranken</name>

--- a/testdata/ggv_ovl-sample-1.gpx
+++ b/testdata/ggv_ovl-sample-1.gpx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gpx version="1.0" creator="ggvtogpx" xmlns="http://www.topografix.com/GPX/1/0">
-  <time>1970-01-01T00:00:00Z</time>
+  <time>1970-01-01T00:00:00+00:00</time>
   <bounds minlat="51.744667000" minlon="10.552068390" maxlat="51.816378030" maxlon="10.690602210"/>
   <wpt lat="51.804391710" lon="10.603572190">
     <name>Symbol 2</name>

--- a/testdata/ggv_ovl-sample-2.gpx
+++ b/testdata/ggv_ovl-sample-2.gpx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gpx version="1.0" creator="ggvtogpx" xmlns="http://www.topografix.com/GPX/1/0">
-  <time>1970-01-01T00:00:00Z</time>
+  <time>1970-01-01T00:00:00+00:00</time>
   <bounds minlat="46.924945000" minlon="10.485110150" maxlat="46.953155790" maxlon="10.511632000"/>
   <trk>
     <name>Track 1</name>

--- a/testdata/ggv_xml-sample-1.gpx
+++ b/testdata/ggv_xml-sample-1.gpx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gpx version="1.0" creator="ggvtogpx" xmlns="http://www.topografix.com/GPX/1/0">
-  <time>1970-01-01T00:00:00Z</time>
+  <time>1970-01-01T00:00:00+00:00</time>
   <bounds minlat="48.331120000" minlon="9.998623000" maxlat="48.577747000" maxlon="10.507993000"/>
   <trk>
     <name>GPSIESTRACK ON GPSIES.COM</name>

--- a/testdata/ggv_xml-sample-2.gpx
+++ b/testdata/ggv_xml-sample-2.gpx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gpx version="1.0" creator="ggvtogpx" xmlns="http://www.topografix.com/GPX/1/0">
-  <time>1970-01-01T00:00:00Z</time>
+  <time>1970-01-01T00:00:00+00:00</time>
   <bounds minlat="48.946518017" minlon="8.922272425" maxlat="48.993516575" maxlon="8.988087787"/>
   <trk>
     <name>Track 001</name>

--- a/testdata/ggv_xml-sample-3.gpx
+++ b/testdata/ggv_xml-sample-3.gpx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gpx version="1.0" creator="ggvtogpx" xmlns="http://www.topografix.com/GPX/1/0">
-  <time>1970-01-01T00:00:00Z</time>
+  <time>1970-01-01T00:00:00+00:00</time>
   <bounds minlat="48.621415806" minlon="10.419878983" maxlat="48.825603564" maxlon="10.700676039"/>
   <wpt lat="48.825603564" lon="10.508117475">
     <ele>432.000000000</ele>

--- a/testdata/ggv_xml-sample-4.gpx
+++ b/testdata/ggv_xml-sample-4.gpx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gpx version="1.0" creator="ggvtogpx" xmlns="http://www.topografix.com/GPX/1/0">
-  <time>1970-01-01T00:00:00Z</time>
+  <time>1970-01-01T00:00:00+00:00</time>
   <bounds minlat="49.298985014" minlon="10.365219042" maxlat="49.340664027" maxlon="10.410564970"/>
   <wpt lat="49.328732061" lon="10.389090399">
     <ele>447.000000000</ele>

--- a/testdata/ggv_xml-sample-5.gpx
+++ b/testdata/ggv_xml-sample-5.gpx
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gpx version="1.0" creator="ggvtogpx" xmlns="http://www.topografix.com/GPX/1/0">
-  <time>1970-01-01T00:00:00Z</time>
+  <time>1970-01-01T00:00:00+00:00</time>
   <bounds minlat="49.287926015" minlon="10.409652013" maxlat="49.328106008" maxlon="10.484346002"/>
   <wpt lat="49.291991011" lon="10.466103387">
     <ele>497.000000000</ele>


### PR DESCRIPTION
- remove Ubuntu 20.04 since Qt 6 is not available
- adjust test cases since ISO time output format slightly changed from "Z" to UTC offset